### PR TITLE
"Reduced version of node to 12.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/Parker9706/gimbap-site.git"
   },
   "engines": {
-    "node": "13.1.0",
+    "node": "12.14.1",
     "npm": "6.12.1",
     "yarn": "1.19.1"
   },


### PR DESCRIPTION
Package exports for '/app/node_modules/colorette' do not define"